### PR TITLE
Further tweaks to driver schema 

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -341,57 +341,6 @@
         }
       ]
     },
-    "drivers": {
-      "title": "Additional drivers",
-      "additionalProperties": {
-        "$comment": {
-          "ref": "driver.schema.json"
-        }
-      }
-    },
-    "timestamp": {
-      "type": "string",
-      "title": "Timestamp",
-      "description": "Timestamp of config",
-      "examples": ["2022-07-30T06:07:48Z"]
-    },
-    "calc_vendor_id": {
-      "type": "string",
-      "title": "Vendor ID to apply to calculated fields (from 'output')",
-      "examples": ["ws-2"]
-    },
-    "push_timeout": {
-      "type": "integer",
-      "deprecated": true,
-      "title": "Timeout for data push (seconds) [deprecated]",
-      "examples": [120]
-    },
-    "read_interval": {
-      "type": "integer",
-      "default": 60,
-      "title": "Interval between readings (seconds)",
-      "examples": [60]
-    },
-    "read_roundtime": {
-      "type": "boolean",
-      "default": false,
-      "title": "Read at round times (based on interval duration)",
-      "examples": [true]
-    },
-    "volatile_q_size": {
-      "type": "integer",
-      "deprecated": true,
-      "title": "Volatile queue size",
-      "description": "Size of volatile queue for data push [deprecated]",
-      "examples": [5]
-    },
-    "push_throttle_delay": {
-      "type": "integer",
-      "deprecated": true,
-      "title": "Push throttle delay",
-      "description": "Delay to throttle data push if unsuccessful [deprecated]",
-      "examples": [15]
-    },
     "status_readings": {
       "type": "array",
       "title": "Status readings",
@@ -411,6 +360,37 @@
           }
         }
       }
+    },
+    "drivers": {
+      "title": "Additional drivers",
+      "additionalProperties": {
+        "$comment": {
+          "ref": "driver.schema.json"
+        }
+      }
+    },
+    "timestamp": {
+      "type": "string",
+      "title": "Timestamp",
+      "description": "Timestamp of config",
+      "examples": ["2022-07-30T06:07:48Z"]
+    },
+    "calc_vendor_id": {
+      "type": "string",
+      "title": "Vendor ID to apply to calculated fields (from 'output')",
+      "examples": ["ws-2"]
+    },
+    "read_interval": {
+      "type": "integer",
+      "default": 60,
+      "title": "Interval between readings (seconds)",
+      "examples": [60]
+    },
+    "read_roundtime": {
+      "type": "boolean",
+      "default": false,
+      "title": "Read at round times (based on interval duration)",
+      "examples": [true]
     }
   }
 }

--- a/driver.schema.json
+++ b/driver.schema.json
@@ -5,138 +5,190 @@
   "title": "Driver schema",
   "required": ["fields"],
   "definitions": {
-    "field_opts": {
+    "common_modbus_reading_opts": {
       "type": "object",
-      "title": "Field options",
+      "title": "Common Modbus reading opts",
       "properties": {
-        "register": {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 65535,
-          "title": "Modbus start register"
-        },
         "fncode": {
           "type": "integer",
-          "enum": [1, 2, 3, 4],
-          "title": "Modbus function code",
+          "format": "u8",
+          "title": "Function code",
+          "description": "Modbus function code",
           "examples": [3, 4]
+        },
+        "register": {
+          "type": "integer",
+          "format": "u16",
+          "minimum": 0,
+          "maximum": 65535,
+          "title": "Register",
+          "description": "Modbus register"
         },
         "words": {
           "type": "integer",
+          "format": "u16",
           "minimum": 1,
           "maximum": 4,
-          "title": "Number of 2-byte words for Modbus",
+          "title": "Words",
+          "description": "Number of 2-byte words for Modbus",
           "examples": [2]
         },
-        "datatype": {
+        "order": {
           "type": "string",
-          "enum": [
-            "int16",
-            "uint16",
-            "int32",
-            "uint32",
-            "int64",
-            "uint64",
-            "float",
-            "double"
-          ],
-          "title": "Source type of data being read",
-          "examples": ["int16"]
+          "title": "Register order",
+          "description": "Register order when parsing multi-register readings",
+          "enum": ["msr", "lsr"]
         },
-        "typecast": {
+        "start_bit": {
+          "type": "integer",
+          "format": "u8",
+          "title": "Start bit",
+          "description": "Start bit, if extracting part of register",
+          "minimum": 0,
+          "maximum": 15
+        },
+        "bit_order": {
           "type": "string",
-          "enum": ["int", "float", "str", "bool"],
-          "title": "Typecast for final processed reading",
-          "examples": ["int"]
+          "title": "Bit order",
+          "description": "Bit order, if extracting part of register",
+          "enum": ["lsb", "msb"]
         },
-        "multiplier": {
-          "type": "number",
-          "title": "Reading multiplier (applied before offset)"
-        },
-        "offset": {
-          "type": "number",
-          "title": "Reading offset (applied after multiplier)"
-        },
-        "datamap": {
-          "type": "object",
-          "title": "Mapping between source and final value"
-        },
-        "unit": {
-          "type": "string",
-          "title": "Unit of reading (not used for data processing)"
-        },
-        "description": {
-          "type": "string",
-          "title": "Description of reading (not used for data processing)"
+        "length_bits": {
+          "type": "integer",
+          "format": "u8",
+          "title": "Length in bits",
+          "description": "Length in bits, if extracting part of register",
+          "minimum": 1,
+          "maximum": 16
         }
       }
     },
-    "status_info_opts": {
+    "common_mqtt_reading_opts": {
       "type": "object",
-      "title": "Status info field map",
-      "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "content": {
-            "type": "string",
-            "title": "Content for the status info",
-            "examples": ["Low Oil Pressure", "High Temperature"]
-          },
-          "register": {
-            "type": "integer",
-            "title": "Modbus register for the status info"
-          },
-          "start_bit": {
-            "type": "integer",
-            "title": "Start bit (within the register) for the status info, first=0",
-            "minimum": 0,
-            "maximum": 15
-          },
-          "fncode": {
-            "type": "integer",
-            "title": "Modbus function code"
-          },
-          "bit_order": {
-            "type": "string",
-            "title": "Bit order",
-            "enum": ["lsb", "msb"]
-          },
-          "length_bits": {
-            "type": "integer",
-            "title": "Length in bits for the status info"
-          },
-          "status_level_value_map": {
-            "type": "array",
-            "title": "Mapping between value and status level",
-            "description": "List of pairs that defines how to map a value to a status level (0=OK, 4=Critical)",
-            "items": {
-              "type": "array",
-              "items": [
-                { "type": "integer", "title": "Value" },
-                {
-                  "type": "integer",
-                  "title": "Numeric Status Level",
-                  "enum": [0, 1, 2, 3, 4]
-                }
+      "title": "Common MQTT reading opts",
+      "properties": {
+        "parse_as": {
+          "type": "string",
+          "enum": ["bytes", "str", "hex"],
+          "title": "Parse input as",
+          "description": "Parse data based on serialization of readout"
+        },
+        "topic": {
+          "type": "string",
+          "title": "Topic",
+          "description": "MQTT topic to subscribe to",
+          "examples": ["sensor/temperature"]
+        }
+      }
+    },
+    "field_opts": {
+      "allOf": [
+        { "$ref": "#/definitions/common_modbus_reading_opts" },
+        { "$ref": "#/definitions/common_mqtt_reading_opts" },
+        {
+          "type": "object",
+          "title": "Field specific opts",
+          "properties": {
+            "datatype": {
+              "type": "string",
+              "enum": [
+                "int16",
+                "uint16",
+                "int32",
+                "uint32",
+                "int64",
+                "uint64",
+                "float",
+                "double"
               ],
-              "minItems": 2,
-              "maxItems": 2
+              "title": "Data type",
+              "description": "Source type of data being read",
+              "examples": ["int16"]
             },
-            "examples": [
-              [
-                [0, 0],
-                [1, 3]
-              ]
-            ]
+            "datamap": {
+              "type": "object",
+              "title": "Data map",
+              "description": "Mapping between source (hex) and final value"
+            },
+            "multiplier": {
+              "type": "number",
+              "title": "Multiplier",
+              "description": "Reading multiplier (applied before offset)"
+            },
+            "offset": {
+              "type": "number",
+              "title": "Reading offset (applied after multiplier)"
+            },
+            "typecast": {
+              "type": "string",
+              "enum": ["int", "float", "str", "bool"],
+              "title": "Typecast for final processed reading",
+              "examples": ["int"]
+            },
+            "unit": {
+              "type": "string",
+              "title": "Unit of reading (not used for data processing)"
+            },
+            "description": {
+              "type": "string",
+              "title": "Description of reading (not used for data processing)"
+            }
           }
         }
+      ]
+    },
+    "status_info_opts": {
+      "type": "object",
+      "title": "Status info opts",
+      "additionalProperties": {
+        "allOf": [
+          { "$ref": "#/definitions/common_modbus_reading_opts" },
+          {
+            "type": "object",
+            "title": "Status info specific opts",
+            "properties": {
+              "content": {
+                "type": "string",
+                "title": "Content",
+                "description": "Content for the status info",
+                "examples": ["Low Oil Pressure", "High Temperature"]
+              },
+              "status_level_value_map": {
+                "type": "array",
+                "title": "Status level value map",
+                "description": "List of pairs that defines how to map a value to a status level (0=OK, 4=Critical)",
+                "items": {
+                  "type": "array",
+                  "items": [
+                    { "type": "integer", "title": "Value", "format": "u8" },
+                    {
+                      "type": "integer",
+                      "title": "Numeric Status Level",
+                      "format": "u8",
+                      "enum": [0, 1, 2, 3, 4]
+                    }
+                  ],
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "examples": [
+                  [
+                    [0, 0],
+                    [1, 3]
+                  ]
+                ]
+              }
+            }
+          }
+        ]
       },
       "examples": [
         {
           "oil_pressure": {
             "content": "Low Oil Pressure",
-            "register": 100,
-            "start_bit": 0
+            "register": 2049,
+            "start_bit": 0,
+            "length_bits": 4
           }
         }
       ]

--- a/driver.schema.json
+++ b/driver.schema.json
@@ -11,16 +11,20 @@
       "properties": {
         "register": {
           "type": "integer",
+          "minimum": 0,
+          "maximum": 65535,
           "title": "Modbus start register"
         },
         "fncode": {
           "type": "integer",
-          "default": 3,
+          "enum": [1, 2, 3, 4],
           "title": "Modbus function code",
           "examples": [3, 4]
         },
         "words": {
           "type": "integer",
+          "minimum": 1,
+          "maximum": 4,
           "title": "Number of 2-byte words for Modbus",
           "examples": [2]
         },
@@ -95,8 +99,7 @@
           "bit_order": {
             "type": "string",
             "title": "Bit order",
-            "enum": ["lsb", "msb"],
-            "default": "lsb"
+            "enum": ["lsb", "msb"]
           },
           "length_bits": {
             "type": "integer",
@@ -159,16 +162,17 @@
         "$ref": "#/definitions/field_opts"
       }
     },
+    "status_info_common": {
+      "$ref": "#/definitions/status_info_opts",
+      "default": {},
+      "title": "Common status info parameters"
+    },
     "status_info": {
-      "title": "Configs per status info key",
+      "title": "Status info items to be read",
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/status_info_opts"
       }
-    },
-    "status_info_common": {
-      "$ref": "#/definitions/status_info_opts",
-      "title": "Fallback if no specific config per status info key is defined"
     }
   }
 }

--- a/driver.schema.json
+++ b/driver.schema.json
@@ -122,7 +122,8 @@
             "typecast": {
               "type": "string",
               "enum": ["int", "float", "str", "bool"],
-              "title": "Typecast for final processed reading",
+              "title": "Typecast",
+              "description": "Typecast for final processed reading",
               "examples": ["int"]
             },
             "unit": {


### PR DESCRIPTION
Wanted to rejig things a bit to make it easier to use from the ammp-edge code.

In particular one thing I removed is the "default" values, because those actually cause subtle issues when you want to apply a `field` item as an override to `common` - or a `status_info` item as an override to `status_info_common`. If for example we set the `fncode` to default to 3, and then set `"status_info_common": {"fncode": 4}`, then a `status_info` item is deserialized, if it's missing an `fncode` _but the schema has a default value set to 3, it will look as if the `status_info` item does contain `{"fncode": 3}`_ and that will override what was set in `status_info_common`. Sneaky!