### PR TITLE
AMM-127 add encombi_csv reading type

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -196,6 +196,7 @@
               "rawserial",
               "rawtcp",
               "sma_hycon_csv",
+              "encombi_csv",
               "sma_speedwire",
               "snmp"
             ],


### PR DESCRIPTION
Adds `encombi_csv` to the `reading_type` enum for the Encombi local FTP/CSV reader (AMM-80), alongside `sma_hycon_csv`.